### PR TITLE
Limiting number of retries & always unlocking

### DIFF
--- a/lib/marloss.rb
+++ b/lib/marloss.rb
@@ -20,9 +20,9 @@ module Marloss
   def self.included(base)
     base.define_singleton_method(:marloss_options) do |opts|
       if opts[:table].nil?
-        raise(MissingParameterError, "DynamoDB Hash Key not set")
-      elsif opts[:hash_key].nil?
         raise(MissingParameterError, "DynamoDB Table not set")
+      elsif opts[:hash_key].nil?
+        raise(MissingParameterError, "DynamoDB Hash Key not set")
       end
 
       define_method(:marloss_options_hash) { opts }
@@ -58,6 +58,7 @@ module Marloss
 
       yield(locker)
 
+    ensure
       locker.release_lock
     end
 

--- a/lib/marloss/locker.rb
+++ b/lib/marloss/locker.rb
@@ -22,9 +22,12 @@ module Marloss
       store.delete_lock(name)
     end
 
-    def wait_until_lock_obtained(sleep_seconds: 3)
+    def wait_until_lock_obtained(sleep_seconds: 3, retries: 3)
       store.create_lock(name)
     rescue LockNotObtainedError
+      raise if retries.zero?
+
+      retries -= 1
       sleep(sleep_seconds)
       retry
     end

--- a/lib/marloss/store.rb
+++ b/lib/marloss/store.rb
@@ -92,7 +92,7 @@ module Marloss
           ":now" => Time.now.to_i,
           ":process_id" => process_id,
         },
-        update_expression: "SET #E = :expires", 
+        update_expression: "SET #E = :expires",
         condition_expression: "attribute_exists(#{hash_key}) AND (#E < :now OR #P = :process_id)"
       )
 
@@ -110,7 +110,8 @@ module Marloss
       Marloss.logger.info("Lock for #{name} deleted successfully")
     end
 
-    private def process_id
+    private
+    def process_id
       hostname = `hostname`.chomp
       pid = Process.pid
 

--- a/spec/lib/marloss/locker_spec.rb
+++ b/spec/lib/marloss/locker_spec.rb
@@ -62,6 +62,17 @@ module Marloss
 
         locker.wait_until_lock_obtained(sleep_seconds: sleep_seconds)
       end
+
+      it "should take a configurable number of retries then fail" do
+
+        allow(store).to receive(:create_lock).with(name)
+          .exactly(5).times.and_raise(LockNotObtainedError)
+
+        allow(locker).to receive(:sleep).with(3)
+        expect {
+          locker.wait_until_lock_obtained(retries: 5)
+        }.to raise_error
+      end
     end
 
   end

--- a/spec/lib/marloss_spec.rb
+++ b/spec/lib/marloss_spec.rb
@@ -94,6 +94,16 @@ describe Marloss do
             expect(locker).to eq(marloss_locker)
           end
         end
+
+        it "should release the lock if an exception is raised in the block" do
+          expect(marloss_locker).to receive(:wait_until_lock_obtained)
+          expect(marloss_locker).to receive(:release_lock)
+
+          class_instance.with_marloss_locker(lock_name) do |locker|
+            expect(locker).to eq(marloss_locker)
+            raise "Error!"
+          end rescue nil
+        end
       end
     end
   end


### PR DESCRIPTION
A couple of fixes:

1) Always unlock, even if the block throws an error
2) We shouldn't spin lock forever, I setup a default of 3 retires before it throws. This is a breaking change.