### PR TITLE
Make create_table wait for table

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Firstly, we need to initialize a lock store:
 store = Marloss::Store.new("lock_table_name", "LockHashKeyName")
 ```
 
+Create table if it does not exist:
+```ruby
+store.create_table
+```
+
 We can use this store to create a single lock
 
 ```ruby
@@ -76,7 +81,7 @@ locker.obtain_lock
 locker.wait_until_lock_obtained
 
 # refresh the lock once
-locker.refresh
+locker.refresh_lock
 
 # delete the lock
 locker.release_lock

--- a/lib/marloss/error.rb
+++ b/lib/marloss/error.rb
@@ -5,6 +5,12 @@ module Marloss
   class Error < StandardError
   end
 
+  class CreateTableError < Error
+  end
+
+  class SetTableTtlError < Error
+  end
+
   class LockNotObtainedError < Error
   end
 

--- a/lib/marloss/store.rb
+++ b/lib/marloss/store.rb
@@ -13,63 +13,69 @@ module Marloss
     end
 
     def create_table
-      begin
-        client.create_table(
-          attribute_definitions: [
-            {
-              attribute_name: hash_key,
-              attribute_type: "S",
-            }
-          ],
-          key_schema: [
-            {
-              attribute_name: hash_key,
-              key_type: "HASH",
-            }
-          ],
-          provisioned_throughput: {
-            read_capacity_units: 5,
-            write_capacity_units: 5,
-          },
-          table_name: table
-        )
-      rescue Aws::DynamoDB::Errors::ResourceInUseException => e
-        case e.message
-        when "Table already exists: #{table}"
-          Marloss.logger.warn("DynamoDB table #{table} already exists")
-        else
-          raise
-        end
-      end
+      create_ddb_table
+      wait_until_ddb_table_exists
+      set_ddb_table_ttl
+    end
+
+    private def create_ddb_table
+      client.create_table(
+        attribute_definitions: [
+          {
+            attribute_name: hash_key,
+            attribute_type: "S",
+          }
+        ],
+        key_schema: [
+          {
+            attribute_name: hash_key,
+            key_type: "HASH",
+          }
+        ],
+        provisioned_throughput: {
+          read_capacity_units: 5,
+          write_capacity_units: 5,
+        },
+        table_name: table
+      )
 
       Marloss.logger.info("DynamoDB table created successfully")
-
-      begin
-        client.wait_until(:table_exists, table_name: table) do |w|
-          w.max_attempts = 10
-          w.delay = 1
-        end
-
-        client.update_time_to_live(
-          table_name: table,
-          time_to_live_specification: {
-            enabled: true,
-            attribute_name: "Expires"
-          }
-        )
-      rescue Aws::Waiters::Errors::WaiterFailed => e
-        Marloss.logger.error("Failed waiting for initialization of table #{table}")
-        raise
-      rescue Aws::DynamoDB::Errors::ValidationException => e
-        case e.message
-        when "TimeToLive is already enabled"
-          Marloss.logger.warn("TTL attribute is already configured for table #{table}")
-        else
-          raise
-        end
+    rescue Aws::DynamoDB::Errors::ResourceInUseException => e
+      case e.message
+      when "Table already exists: #{table}"
+        Marloss.logger.warn("DynamoDB table #{table} already exists")
+      else
+        raise(CreateTableError, e.message)
       end
+    end
+
+    private def wait_until_ddb_table_exists
+      client.wait_until(:table_exists, table_name: table) do |w|
+        w.max_attempts = 10
+        w.delay = 1
+      end
+    rescue Aws::Waiters::Errors::WaiterFailed => e
+      Marloss.logger.error("Failed waiting for initialization of table #{table}")
+      raise(CreateTableError, e.message)
+    end
+
+    private def set_ddb_table_ttl
+      client.update_time_to_live(
+        table_name: table,
+        time_to_live_specification: {
+          enabled: true,
+          attribute_name: "Expires"
+        }
+      )
 
       Marloss.logger.info("DynamoDB table TTL configured successfully")
+    rescue Aws::DynamoDB::Errors::ValidationException => e
+      case e.message
+      when "TimeToLive is already enabled"
+        Marloss.logger.warn("TTL attribute is already configured for table #{table}")
+      else
+        raise(SetTableTtlError, e.message)
+      end
     end
 
     def delete_table

--- a/spec/lib/marloss/store_spec.rb
+++ b/spec/lib/marloss/store_spec.rb
@@ -45,6 +45,10 @@ module Marloss
           }, 
           table_name: table
         )
+        expect(ddb_client).to receive(:wait_until).with(
+          :table_exists,
+          table_name: table
+        )
         expect(ddb_client).to receive(:update_time_to_live).with(
           table_name: table,
           time_to_live_specification: {


### PR DESCRIPTION
It takes some time to initialize DynamoDB table, and previously I was getting this errors on creation:
```
Aws::DynamoDB::Errors::ResourceInUseException: Attempt to change a resource which is still in use: Table lock_table_name is being created
```
or
```
Aws::DynamoDB::Errors::ResourceNotFoundException: Requested resource not found: Table: lock_table_name not found
```

Plus I made this call idempotent, allowing to make `create_table` call on existing tables.