### PR TITLE
Add a custom_process_id parameter for use with lambda

### DIFF
--- a/lib/marloss/store.rb
+++ b/lib/marloss/store.rb
@@ -2,14 +2,16 @@
 
 module Marloss
   class Store # rubocop:disable Metrics/ClassLength
-    attr_reader :client, :table, :hash_key, :expires_key, :ttl
+    attr_reader :client, :table, :hash_key, :expires_key, :ttl, :unique_process_id
 
-    def initialize(table, hash_key, expires_key: "Expires", ttl: 30, client_options: {})
+    def initialize(table, hash_key, **options)
+      client_options = options[:client_options] || {}
       @client = Aws::DynamoDB::Client.new(client_options)
       @table = table
       @hash_key = hash_key
-      @expires_key = expires_key
-      @ttl = ttl
+      @expires_key = options[:expires_key] || "Expires"
+      @ttl = options[:ttl] || 30
+      @unique_process_id = options[:unique_process_id] || nil
     end
 
     def create_table
@@ -141,6 +143,8 @@ module Marloss
     end
 
     private def process_id
+      return unique_process_id unless unique_process_id.nil?
+
       hostname = `hostname`.chomp
       pid = Process.pid
 

--- a/lib/marloss/store.rb
+++ b/lib/marloss/store.rb
@@ -2,16 +2,16 @@
 
 module Marloss
   class Store # rubocop:disable Metrics/ClassLength
-    attr_reader :client, :table, :hash_key, :expires_key, :ttl, :unique_process_id
+    attr_reader :client, :table, :hash_key, :expires_key, :ttl, :custom_process_id
 
     def initialize(table, hash_key, **options)
-      client_options = options[:client_options] || {}
+      client_options = options.fetch(:client_options, {})
       @client = Aws::DynamoDB::Client.new(client_options)
       @table = table
       @hash_key = hash_key
-      @expires_key = options[:expires_key] || "Expires"
-      @ttl = options[:ttl] || 30
-      @unique_process_id = options[:unique_process_id] || nil
+      @expires_key = options.fetch(:expires_key, "Expires")
+      @ttl = options.fetch(:ttl, 30)
+      @custom_process_id = options.fetch(:custom_process_id, nil)
     end
 
     def create_table
@@ -143,7 +143,7 @@ module Marloss
     end
 
     private def process_id
-      return unique_process_id unless unique_process_id.nil?
+      return custom_process_id if custom_process_id
 
       hostname = `hostname`.chomp
       pid = Process.pid

--- a/lib/marloss/store.rb
+++ b/lib/marloss/store.rb
@@ -2,7 +2,7 @@
 
 module Marloss
   class Store # rubocop:disable Metrics/ClassLength
-    attr_reader :client, :table, :hash_key, :expires_key, :ttl, :custom_process_id
+    attr_reader :client, :table, :hash_key, :expires_key, :ttl, :process_id
 
     def initialize(table, hash_key, **options)
       client_options = options.fetch(:client_options, {})
@@ -11,7 +11,7 @@ module Marloss
       @hash_key = hash_key
       @expires_key = options.fetch(:expires_key, "Expires")
       @ttl = options.fetch(:ttl, 30)
-      @custom_process_id = options.fetch(:custom_process_id, nil)
+      @process_id = options[:custom_process_id] || host_process_id
     end
 
     def create_table
@@ -142,9 +142,7 @@ module Marloss
       Marloss.logger.info("Lock for #{name} deleted successfully")
     end
 
-    private def process_id
-      return custom_process_id if custom_process_id
-
+    private def host_process_id
       hostname = `hostname`.chomp
       pid = Process.pid
 

--- a/spec/lib/marloss/store_spec.rb
+++ b/spec/lib/marloss/store_spec.rb
@@ -8,11 +8,11 @@ describe Marloss::Store do
   let(:ttl) { 10 }
   let(:client_options) { {} }
   let(:store) { described_class.new(table, hash_key, ttl: ttl, client_options: client_options) }
-  let(:unique_process_id) { "58a0b601" }
-  let(:unique_process_options) do
-    { ttl: ttl, client_options: client_options, unique_process_id: unique_process_id }
+  let(:custom_process_id) { "58a0b601" }
+  let(:custom_process_options) do
+    { ttl: ttl, client_options: client_options, custom_process_id: custom_process_id }
   end
-  let(:unique_process_store) { described_class.new(table, hash_key, unique_process_options) }
+  let(:custom_process_store) { described_class.new(table, hash_key, custom_process_options) }
 
   let(:name) { "my_resource" }
   let(:hostname) { "hostname.local" }
@@ -95,12 +95,12 @@ describe Marloss::Store do
       store.create_lock(name)
     end
 
-    it "should create the lock with a unique process id" do
+    it "should create the lock with a custom process id" do
       expect(ddb_client).to receive(:put_item).with(
         table_name: table,
         item: {
           hash_key => name,
-          "ProcessID" => unique_process_id,
+          "ProcessID" => custom_process_id,
           "Expires" => expires
         },
         expression_attribute_names: {
@@ -109,12 +109,12 @@ describe Marloss::Store do
         },
         expression_attribute_values: {
           ":now" => Time.now.to_i,
-          ":process_id" => unique_process_id
+          ":process_id" => custom_process_id
         },
         condition_expression: "attribute_not_exists(#{hash_key}) OR #E < :now OR #P = :process_id"
       )
 
-      unique_process_store.create_lock(name)
+      custom_process_store.create_lock(name)
     end
 
     it "should fail creating the lock and raise error" do

--- a/spec/lib/marloss/store_spec.rb
+++ b/spec/lib/marloss/store_spec.rb
@@ -7,13 +7,11 @@ describe Marloss::Store do
   let(:hash_key) { "LockID" }
   let(:ttl) { 10 }
   let(:client_options) { {} }
-  let(:store) { described_class.new(table, hash_key, ttl: ttl, client_options: client_options) }
-  let(:custom_process_id) { "58a0b601" }
-  let(:custom_process_options) do
+  let(:custom_process_id) { nil }
+  let(:options) do
     { ttl: ttl, client_options: client_options, custom_process_id: custom_process_id }
   end
-  let(:custom_process_store) { described_class.new(table, hash_key, custom_process_options) }
-
+  let(:store) { described_class.new(table, hash_key, options) }
   let(:name) { "my_resource" }
   let(:hostname) { "hostname.local" }
   let(:pid) { 86_776 }
@@ -23,7 +21,7 @@ describe Marloss::Store do
   before do
     allow(Aws::DynamoDB::Client).to receive(:new).with(client_options)
       .and_return(ddb_client)
-    allow(store).to receive(:`).with("hostname").and_return(hostname)
+    allow_any_instance_of(described_class).to receive(:`).with("hostname").and_return(hostname)
     allow(Process).to receive(:pid).and_return(pid)
   end
 
@@ -95,28 +93,6 @@ describe Marloss::Store do
       store.create_lock(name)
     end
 
-    it "should create the lock with a custom process id" do
-      expect(ddb_client).to receive(:put_item).with(
-        table_name: table,
-        item: {
-          hash_key => name,
-          "ProcessID" => custom_process_id,
-          "Expires" => expires
-        },
-        expression_attribute_names: {
-          "#E" => "Expires",
-          "#P" => "ProcessID"
-        },
-        expression_attribute_values: {
-          ":now" => Time.now.to_i,
-          ":process_id" => custom_process_id
-        },
-        condition_expression: "attribute_not_exists(#{hash_key}) OR #E < :now OR #P = :process_id"
-      )
-
-      custom_process_store.create_lock(name)
-    end
-
     it "should fail creating the lock and raise error" do
       allow(ddb_client).to receive(:put_item).with(
         table_name: table,
@@ -137,6 +113,32 @@ describe Marloss::Store do
       ).and_raise(ddb_error)
 
       expect { store.create_lock(name) }.to raise_error(Marloss::LockNotObtainedError)
+    end
+  end
+
+  context "with custom process id" do
+    let(:custom_process_id) { "58a0b601" }
+
+    it "should create the lock" do
+      expect(ddb_client).to receive(:put_item).with(
+        table_name: table,
+        item: {
+          hash_key => name,
+          "ProcessID" => custom_process_id,
+          "Expires" => expires
+        },
+        expression_attribute_names: {
+          "#E" => "Expires",
+          "#P" => "ProcessID"
+        },
+        expression_attribute_values: {
+          ":now" => Time.now.to_i,
+          ":process_id" => custom_process_id
+        },
+        condition_expression: "attribute_not_exists(#{hash_key}) OR #E < :now OR #P = :process_id"
+      )
+
+      store.create_lock(name)
     end
   end
 


### PR DESCRIPTION
I found that using this with a lambda function ended up with the same hostname & PID (inside the containers) for multiple runs.  This adds the option to specify a `custom_process_id`, for example I'm using the `context.aws_request_id`.

Had to do a little extra to keep rubocop happy :)