### PR TITLE
update ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
-  - 2.2.10
+  - 2.6.1
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
 notifications:
   email: false
 before_script: bundle exec rubocop

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Marloss is a general DynamoDB-based lock implementation.
 
 ![rusty-lock](https://user-images.githubusercontent.com/10990391/33243215-aa602a6c-d2d9-11e7-8fc6-d4a0c2a5b30d.jpg)
 
+This Gem is tested using Ruby 2.6, 2.5, 2.4, 2.3
+
 ### Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
update ruby versions with the latest https://www.ruby-lang.org/en/downloads/
this PR is removing ruby 2.2 from the versions used in travis as is "Not maintained anymore (EOL)"