### PR TITLE
Add a custom_process_id parameter for use with lambda

### DIFF
--- a/lib/marloss/store.rb
+++ b/lib/marloss/store.rb
@@ -2,14 +2,16 @@
 
 module Marloss
   class Store # rubocop:disable Metrics/ClassLength
-    attr_reader :client, :table, :hash_key, :expires_key, :ttl
+    attr_reader :client, :table, :hash_key, :expires_key, :ttl, :process_id
 
-    def initialize(table, hash_key, expires_key: "Expires", ttl: 30, client_options: {})
+    def initialize(table, hash_key, **options)
+      client_options = options.fetch(:client_options, {})
       @client = Aws::DynamoDB::Client.new(client_options)
       @table = table
       @hash_key = hash_key
-      @expires_key = expires_key
-      @ttl = ttl
+      @expires_key = options.fetch(:expires_key, "Expires")
+      @ttl = options.fetch(:ttl, 30)
+      @process_id = options[:custom_process_id] || host_process_id
     end
 
     def create_table
@@ -140,7 +142,7 @@ module Marloss
       Marloss.logger.info("Lock for #{name} deleted successfully")
     end
 
-    private def process_id
+    private def host_process_id
       hostname = `hostname`.chomp
       pid = Process.pid
 


### PR DESCRIPTION
I found that using this with a lambda function ended up with the same hostname & PID (inside the containers) for multiple runs. This adds the option to specify a `custom_process_id`, for example I'm using the `context.aws_request_id`.