### PR TITLE
Fix 2 failing specs by adding message value to test struct

### DIFF
--- a/spec/lib/marloss/store_spec.rb
+++ b/spec/lib/marloss/store_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Marloss::Store do
   let(:ddb_client) { instance_double(Aws::DynamoDB::Client) }
-  let(:ddb_error) { Aws::DynamoDB::Errors::ConditionalCheckFailedException.new(nil, nil) }
+  let(:ddb_error) { Aws::DynamoDB::Errors::ConditionalCheckFailedException.new(nil, "An error message") }
   let(:table) { "my_table" }
   let(:hash_key) { "LockID" }
   let(:ttl) { 10 }


### PR DESCRIPTION
Two specs fail as there is no `message` member in the Exception returned
by a mocked function call.

```
  1) Marloss::Store.create_lock should fail creating the lock and raise error
     Failure/Error: expect { store.create_lock(name) }.to raise_error(Marloss::LockNotObtainedError)

       expected Marloss::LockNotObtainedError, got #<NameError: no member 'message' in struct> with backtrace:
         # ./lib/marloss/store.rb:112:in `rescue in create_lock'
         # ./lib/marloss/store.rb:89:in `create_lock'
         # ./spec/lib/marloss/store_spec.rb:115:in `block (4 levels) in <top (required)>'
         # ./spec/lib/marloss/store_spec.rb:115:in `block (3 levels) in <top (required)>'
     # ./spec/lib/marloss/store_spec.rb:115:in `block (3 levels) in <top (required)>
```

Add the `message` value to the mocked exception.

Clearly this must work without this message being set under some
circumstances or it would not be merged into the repo. I am using the
versions of the gems from the Gemfile, and a freshly compiled Ruby 2.4.3 .