### PR TITLE
Only release lock if we obtained it

### DIFF
--- a/lib/marloss.rb
+++ b/lib/marloss.rb
@@ -50,13 +50,15 @@ module Marloss
     end
 
     def with_marloss_locker(name, opts = {})
+      have_lock = false
       locker = marloss_locker(name)
 
       locker.wait_until_lock_obtained(opts)
+      have_lock = true
 
       yield(locker)
     ensure
-      locker.release_lock
+      locker.release_lock if have_lock
     end
   end
 end

--- a/spec/lib/marloss_spec.rb
+++ b/spec/lib/marloss_spec.rb
@@ -93,6 +93,15 @@ describe Marloss do
             expect(locker).to eq(marloss_locker)
           end
         end
+
+        it "should not release lock if it was not obtained" do
+          expect(marloss_locker).to receive(:wait_until_lock_obtained).and_raise Marloss::LockNotObtainedError
+          expect(marloss_locker).not_to receive(:release_lock)
+
+          expect do
+            class_instance.with_marloss_locker(lock_name)
+          end.to raise_error(Marloss::LockNotObtainedError)
+        end
       end
     end
   end


### PR DESCRIPTION
`with_marloss_locker` has an ensure section that makes sure that we
release the lock even if an error occurs.

It does not guarantee that we had actually obtained the lock. Thus it
will release a lock that another process has obtained. This will happen
in the case of an attempt to obtain the lock failing due to max retries,
and raising Marloss::LockNotObtainedError.

Ensure that we have the lock before we release it.